### PR TITLE
Fix wrong fields and invalid where params

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "loopback-softdelete-mixin",
   "version": "0.0.6",
   "description": "A mixin to automatically generate created and updated Date attributes for loopback Models",
-  "main": "dist/index.js",
+  "main": "index.js",
   "scripts": {
     "preversion": "npm test",
     "pretest": "eslint ./src/*.js && gulp babel",

--- a/src/soft-delete.js
+++ b/src/soft-delete.js
@@ -51,12 +51,12 @@ export default (Model, { deletedAt = 'deletedAt', _isDeleted = '_isDeleted', scr
   Model.prototype.delete = Model.prototype.destroy;
 
   // Emulate default scope but with more flexibility.
-  const queryNonDeleted = {_isDeleted: false};
+  const queryNonDeleted = {[_isDeleted]: false};
 
   const _findOrCreate = Model.findOrCreate;
   Model.findOrCreate = function findOrCreateDeleted(query = {}, ...rest) {
     if (!query.deleted) {
-      if (!query.where) {
+      if (!query.where || Object.keys(query.where).length === 0) {
         query.where = queryNonDeleted;
       } else {
         query.where = { and: [ query.where, queryNonDeleted ] };
@@ -69,7 +69,7 @@ export default (Model, { deletedAt = 'deletedAt', _isDeleted = '_isDeleted', scr
   const _find = Model.find;
   Model.find = function findDeleted(query = {}, ...rest) {
     if (!query.deleted) {
-      if (!query.where) {
+      if (!query.where || Object.keys(query.where).length === 0) {
         query.where = queryNonDeleted;
       } else {
         query.where = { and: [ query.where, queryNonDeleted ] };
@@ -82,14 +82,15 @@ export default (Model, { deletedAt = 'deletedAt', _isDeleted = '_isDeleted', scr
   const _count = Model.count;
   Model.count = function countDeleted(where = {}, ...rest) {
     // Because count only receives a 'where', there's nowhere to ask for the deleted entities.
-    const whereNotDeleted = { and: [ where, queryNonDeleted ] };
+    const whereNotDeleted = (!where || Object.keys(where).length === 0) ? queryNonDeleted : { and: [ where, queryNonDeleted ] };
+
     return _count.call(Model, whereNotDeleted, ...rest);
   };
 
   const _update = Model.update;
   Model.update = Model.updateAll = function updateDeleted(where = {}, ...rest) {
     // Because update/updateAll only receives a 'where', there's nowhere to ask for the deleted entities.
-    const whereNotDeleted = { and: [ where, queryNonDeleted ] };
+    const whereNotDeleted = (!where || Object.keys(where).length === 0) ? queryNonDeleted : { and: [ where, queryNonDeleted ] };
     return _update.call(Model, whereNotDeleted, ...rest);
   };
 };


### PR DESCRIPTION
Hi there,

Just fall into some issues using this module on a team project.

Basicaly, if we change the name of the `_isDeleted` property, it is not replicated in the `queryNonDeleted` where param.

Also, in some case we can send query with empty where object, and this was merged with the `queryNonDeleted` param which cause SQL issue.

Feel free to discuss if you want something to be changed ! 👍 